### PR TITLE
Avoid IllegalThreadStateException when setting a custom CloseableHttpAsyncClient.

### DIFF
--- a/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
+++ b/src/main/java/com/mashape/unirest/http/HttpClientHelper.java
@@ -97,7 +97,9 @@ public class HttpClientHelper {
 		if (!asyncHttpClient.isRunning()) {
 			asyncHttpClient.start();
 			AsyncIdleConnectionMonitorThread asyncIdleConnectionMonitorThread = (AsyncIdleConnectionMonitorThread) Options.getOption(Option.ASYNC_MONITOR);
-			asyncIdleConnectionMonitorThread.start();
+			if (!asyncIdleConnectionMonitorThread.isAlive()) {
+				asyncIdleConnectionMonitorThread.start();
+			}
 		}
 
 		final Future<org.apache.http.HttpResponse> future = asyncHttpClient.execute(requestObj,


### PR DESCRIPTION
If the ASYNC_MONITOR AsyncIdleConnectionMonitorThread is already started it'll crash., thing that happens when setting a custom CloseableHttpAsyncClient.
Added a check, so it won't happen.